### PR TITLE
Issue 54 riscv nanbox

### DIFF
--- a/sim/op-riscv.c
+++ b/sim/op-riscv.c
@@ -1,9 +1,9 @@
 /*
 	Copyright (c) 2017-2018, Zhengyang Gu (author)
- 
+
 	All rights reserved.
 
-	Redistribution and use in source and binary forms, with or without 
+	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions
 	are met:
 
@@ -18,20 +18,20 @@
 
 	*	Neither the name of the author nor the names of its
 		contributors may be used to endorse or promote products
-		derived from this software without specific prior written 
+		derived from this software without specific prior written
 		permission.
 
 	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 	"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-	FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+	FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
 	COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 	INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-	BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+	BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 	CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-	LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-	ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+	LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+	ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
 #include <stdio.h>
@@ -82,7 +82,7 @@ void riscv_sub(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 
 void riscv_slt(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
-	
+
 	if ((int32_t) reg_read_riscv(E, S, rs1) < (int32_t) reg_read_riscv(E, S, rs2))
 	{
 		reg_set_riscv(E, S, rd, 1);
@@ -97,7 +97,7 @@ void riscv_slt(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 
 void riscv_sltu(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
-	
+
 	if (reg_read_riscv(E, S, rs1) < reg_read_riscv(E, S, rs2))
 	{
 		reg_set_riscv(E, S, rd, 1);
@@ -222,7 +222,7 @@ void riscv_slli(Engine *E, State *S, uint8_t rs1, uint8_t rd, uint32_t imm0)
 {
 	int xlen_b = 5;
 	int mask = ((1 << xlen_b) - 1);
-	uint8_t shift = imm0 & mask; 
+	uint8_t shift = imm0 & mask;
 
 	reg_set_riscv(E, S, rd, (reg_read_riscv(E, S, rs1) << shift));
 
@@ -233,7 +233,7 @@ void riscv_srli(Engine *E, State *S, uint8_t rs1, uint8_t rd, uint32_t imm0)
 {
 	int xlen_b = 5;
 	int mask = ((1 << xlen_b) - 1);
-	uint8_t shift = imm0 & mask; 
+	uint8_t shift = imm0 & mask;
 
 	reg_set_riscv(E, S, rd, (reg_read_riscv(E, S, rs1) >> shift));
 
@@ -244,7 +244,7 @@ void riscv_srai(Engine *E, State *S, uint8_t rs1, uint8_t rd, uint32_t imm0)
 {
 	int xlen_b = 5;
 	int mask = ((1 << xlen_b) - 1);
-	uint8_t shift = imm0 & mask; 
+	uint8_t shift = imm0 & mask;
 	uint32_t data = ((signed int)reg_read_riscv(E, S, rs1)) >> shift;
 	reg_set_riscv(E, S, rd, data);
 
@@ -278,7 +278,7 @@ void riscv_jal(Engine *E, State *S, uint8_t rd, uint16_t imm1, uint8_t imm11, ui
 void riscv_jalr(Engine *E, State *S, uint8_t rs1, uint8_t rd, uint16_t imm0)
 {
 	int32_t addr = (int32_t) sign_extend(imm0, 12) + (int32_t) reg_read_riscv(E, S, rs1);
-	
+
 	uint32_t mask = -2;
 
 	reg_set_riscv(E, S, rd, S->PC);
@@ -369,9 +369,9 @@ void riscv_bgeu(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t imm1, uin
 void riscv_lw(Engine *E, State *S, uint8_t rs1, uint8_t rd, uint16_t imm0)
 {
 	uint32_t addr = reg_read_riscv(E,S, rs1) + sign_extend(imm0, 12);
-	
+
 	uint32_t value = superHreadlong(E, S, addr);
-	
+
 	reg_set_riscv(E, S, rd, value);
 
 	return;
@@ -420,9 +420,9 @@ void riscv_lbu(Engine *E, State *S, uint8_t rs1, uint8_t rd, uint16_t imm0)
 void riscv_sw(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint16_t imm0, uint16_t imm5)
 {
 	uint32_t addr = reg_read_riscv(E,S, rs1) + sign_extend(imm0 + (imm5 << 5), 12);
-	
+
 	uint32_t value = reg_read_riscv(E,S, rs2);
-	
+
 	superHwritelong(E, S, addr, value);
 }
 
@@ -468,192 +468,192 @@ void rv32f_fsw(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint16_t imm0, uin
 	uint32_t addr = reg_read_riscv(E, S, rs1) + sign_extend(imm0 + (imm5 << 5), 12);
 
 	superHwritelong(E, S, addr, freg_read_riscv(E, S, rs2));
-	
+
 	return;
 }
 
 void rv32f_fmadd_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rs3, uint8_t rm, uint8_t rd)
 {
 	rv32f_rep src1, src2, src3, result;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
 	src2.bit_value = freg_read_riscv(E, S, rs2);
 	src3.bit_value = freg_read_riscv(E, S, rs3);
-	
+
 	result.float_value = (src1.float_value * src2.float_value) + src3.float_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit_value);
-	
+
 	return;
 }
 
 void rv32f_fmsub_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rs3, uint8_t rm, uint8_t rd)
-{	
+{
 	rv32f_rep src1, src2, src3, result;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
 	src2.bit_value = freg_read_riscv(E, S, rs2);
 	src3.bit_value = freg_read_riscv(E, S, rs3);
-	
+
 	result.float_value = (src1.float_value * src2.float_value) - src3.float_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit_value);
-	
+
 	return;
 }
 
 void rv32f_fnmsub_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rs3, uint8_t rm, uint8_t rd)
 {
 	rv32f_rep src1, src2, src3, result;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
 	src2.bit_value = freg_read_riscv(E, S, rs2);
 	src3.bit_value = freg_read_riscv(E, S, rs3);
-	
+
 	result.float_value = (-1.0 * src1.float_value * src2.float_value) + src3.float_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit_value);
-	
+
 	return;
 }
 
 void rv32f_fnmadd_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rs3, uint8_t rm, uint8_t rd)
 {
 	rv32f_rep src1, src2, src3, result;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
 	src2.bit_value = freg_read_riscv(E, S, rs2);
 	src3.bit_value = freg_read_riscv(E, S, rs3);
-	
+
 	result.float_value = (-1.0 * src1.float_value * src2.float_value) - src3.float_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit_value);
-	
+
 	return;
 }
 
 void rv32f_fadd_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	rv32f_rep src1, src2, result;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
 	src2.bit_value = freg_read_riscv(E, S, rs2);
-	
+
 	result.float_value = src1.float_value + src2.float_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit_value);
-	
+
 	return;
 }
 
 void rv32f_fsub_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	rv32f_rep src1, src2, result;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
 	src2.bit_value = freg_read_riscv(E, S, rs2);
-	
+
 	result.float_value = src1.float_value - src2.float_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit_value);
-	
+
 	return;
 }
 
 void rv32f_fmul_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
-	
+
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	rv32f_rep src1, src2, result;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
 	src2.bit_value = freg_read_riscv(E, S, rs2);
-	
+
 	result.float_value = src1.float_value * src2.float_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit_value);
-	
+
 	return;
 }
 
 void rv32f_fdiv_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	rv32f_rep src1, src2, result;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
 	src2.bit_value = freg_read_riscv(E, S, rs2);
-	
+
 	result.float_value = src1.float_value / src2.float_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit_value);
-	
+
 	return;
 }
 
 void rv32f_fsqrt_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	rv32f_rep src1, result;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
-	
+
 	result.float_value = sqrtf(src1.float_value);
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit_value);
-	
+
 	return;
 }
 
@@ -661,11 +661,11 @@ void rv32f_fsgnj_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	uint32_t src1 = freg_read_riscv(E, S, rs1);
 	uint32_t src2 = freg_read_riscv(E, S, rs2);
-	
+
 	uint32_t result = (src1 & (-1 - (1 << 31))) | (src2 & (1 << 31));
-	
+
 	freg_set_riscv(E, S, rd, result);
-	
+
 	return;
 }
 
@@ -673,11 +673,11 @@ void rv32f_fsgnjn_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	uint32_t src1 = freg_read_riscv(E, S, rs1);
 	uint32_t src2 = freg_read_riscv(E, S, rs2);
-	
+
 	uint32_t result = (src1 & (-1 - (1 << 31))) | (~src2 & (1 << 31));
-	
+
 	freg_set_riscv(E, S, rd, result);
-	
+
 	return;
 }
 
@@ -685,47 +685,47 @@ void rv32f_fsgnjx_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	uint32_t src1 = freg_read_riscv(E, S, rs1);
 	uint32_t src2 = freg_read_riscv(E, S, rs2);
-	
+
 	uint32_t result = (src1 & (-1 - (1 << 31))) | ((src1 ^ src2) & (1 << 31));
-	
+
 	freg_set_riscv(E, S, rd, result);
-	
+
 	return;
 }
 
 void rv32f_fmin_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	rv32f_rep src1, src2;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
 	src2.bit_value = freg_read_riscv(E, S, rs2);
-	
+
 	freg_set_riscv(E, S, rd, (src1.float_value <= src2.float_value) ? src1.bit_value : src2.bit_value);
-	
+
 	return;
 }
 
 void rv32f_fmax_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	rv32f_rep src1, src2;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
 	src2.bit_value = freg_read_riscv(E, S, rs2);
-	
+
 	freg_set_riscv(E, S, rd, (src1.float_value >= src2.float_value) ? src1.bit_value : src2.bit_value);
-	
+
 	return;
 }
 
 void rv32f_fcvt_w_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	rv32f_rep src1;
-	
+
 	uint8_t frm;
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
-	
+
 	/*
 	*Rounding modes - Reference
 	*https://www.gnu.org/software/libc/manual/html_node/Rounding-Functions.html
@@ -735,27 +735,27 @@ void rv32f_fcvt_w_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 		case 0b000: //Round to nearest (ties to Even)
 			reg_set_riscv(E, S, rd, (int32_t)rintf(src1.float_value));
 			break;
-		
+
 		case 0b001: //Round towards zero
 			reg_set_riscv(E, S, rd, (int32_t)truncf(src1.float_value));
 			break;
-		
+
 		case 0b010:	//Round down (towards -inf)
 			reg_set_riscv(E, S, rd, (int32_t)floorf(src1.float_value));
 			break;
-		
+
 		case 0b011: //Round up (towards +inf)
 			reg_set_riscv(E, S, rd, (int32_t)ceilf(src1.float_value));
 			break;
-		
+
 		case 0b100: //Round to nearest (ties to Max Magnitude)
 			reg_set_riscv(E, S, rd, (int32_t)roundf(src1.float_value));
 			break;
-		
+
 		case 0b101: //Invalid. Reserved for future use
 		case 0b110: //Do nothing for now
 			break;
-		
+
 		case 0b111: //Dynamic rounding mode, read from frm
 			frm = (S->riscv->fCSR & (0b111 << 5)) >> 5;
 			switch (frm)
@@ -763,23 +763,23 @@ void rv32f_fcvt_w_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 				case 0b000: //Round to nearest (ties to Even)
 					reg_set_riscv(E, S, rd, (int32_t)rintf(src1.float_value));
 					break;
-				
+
 				case 0b001: //Round towards zero
 					reg_set_riscv(E, S, rd, (int32_t)truncf(src1.float_value));
 					break;
-				
+
 				case 0b010:	//Round down (towards -inf)
 					reg_set_riscv(E, S, rd, (int32_t)floorf(src1.float_value));
 					break;
-				
+
 				case 0b011: //Round up (towards +inf)
 					reg_set_riscv(E, S, rd, (int32_t)ceilf(src1.float_value));
 					break;
-				
+
 				case 0b100: //Round to nearest (ties to Max Magnitude)
 					reg_set_riscv(E, S, rd, (int32_t)roundf(src1.float_value));
 					break;
-				
+
 				case 0b101: //Invalid
 				case 0b110: //Do nothing for now
 				case 0b111:
@@ -787,23 +787,23 @@ void rv32f_fcvt_w_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 					break;
 			}
 			break;
-		
+
 		default:
 			break;
 	}
-	
+
 	return;
 }
 
 void rv32f_fcvt_wu_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	rv32f_rep src1;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
-	
+
 	uint8_t frm;
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	/*
 	*Rounding modes - Reference
 	*https://www.gnu.org/software/libc/manual/html_node/Rounding-Functions.html
@@ -813,27 +813,27 @@ void rv32f_fcvt_wu_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 		case 0b000: //Round to nearest (ties to Even)
 			reg_set_riscv(E, S, rd, (uint32_t)rintf(src1.float_value));
 			break;
-		
+
 		case 0b001: //Round towards zero
 			reg_set_riscv(E, S, rd, (uint32_t)truncf(src1.float_value));
 			break;
-		
+
 		case 0b010:	//Round down (towards -inf)
 			reg_set_riscv(E, S, rd, (uint32_t)floorf(src1.float_value));
 			break;
-		
+
 		case 0b011: //Round up (towards +inf)
 			reg_set_riscv(E, S, rd, (uint32_t)ceilf(src1.float_value));
 			break;
-		
+
 		case 0b100: //Round to nearest (ties to Max Magnitude)
 			reg_set_riscv(E, S, rd, (uint32_t)roundf(src1.float_value));
 			break;
-		
+
 		case 0b101: //Invalid. Reserved for future use
 		case 0b110: //Do nothing for now
 			break;
-		
+
 		case 0b111: //Dynamic rounding mode, read from frm
 			frm = (S->riscv->fCSR & (0b111 << 5)) >> 5;
 			switch (frm)
@@ -841,23 +841,23 @@ void rv32f_fcvt_wu_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 				case 0b000: //Round to nearest (ties to Even)
 					reg_set_riscv(E, S, rd, (uint32_t)rintf(src1.float_value));
 					break;
-				
+
 				case 0b001: //Round towards zero
 					reg_set_riscv(E, S, rd, (uint32_t)truncf(src1.float_value));
 					break;
-				
+
 				case 0b010:	//Round down (towards -inf)
 					reg_set_riscv(E, S, rd, (uint32_t)floorf(src1.float_value));
 					break;
-				
+
 				case 0b011: //Round up (towards +inf)
 					reg_set_riscv(E, S, rd, (uint32_t)ceilf(src1.float_value));
 					break;
-				
+
 				case 0b100: //Round to nearest (ties to Max Magnitude)
 					reg_set_riscv(E, S, rd, (uint32_t)roundf(src1.float_value));
 					break;
-				
+
 				case 0b101: //Invalid
 				case 0b110: //Do nothing for now
 				case 0b111:
@@ -865,54 +865,54 @@ void rv32f_fcvt_wu_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 					break;
 			}
 			break;
-		
+
 		default:
 			break;
 	}
-	
+
 	return;
 }
 
 void rv32f_fmv_x_w(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	reg_set_riscv(E, S, rd, freg_read_riscv(E, S, rs1));
-	
+
 	return;
 }
 
 void rv32f_feq_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	rv32f_rep src1, src2;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
 	src2.bit_value = freg_read_riscv(E, S, rs2);
-	
+
 	reg_set_riscv(E, S, rd, (src1.float_value == src2.float_value) ? 1 : 0);
-	
+
 	return;
 }
 
 void rv32f_flt_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	rv32f_rep src1, src2;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
 	src2.bit_value = freg_read_riscv(E, S, rs2);
-	
+
 	reg_set_riscv(E, S, rd, (src1.float_value < src2.float_value) ? 1 : 0);
-	
+
 	return;
 }
 
 void rv32f_fle_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	rv32f_rep src1, src2;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
 	src2.bit_value = freg_read_riscv(E, S, rs2);
-	
+
 	reg_set_riscv(E, S, rd, (src1.float_value <= src2.float_value) ? 1 : 0);
-	
+
 	return;
 }
 
@@ -922,77 +922,77 @@ void rv32f_fclass_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 	//TODO
 	uint32_t shift;
 	rv32f_rep src1;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
-	
+
 	int class = fpclassify(src1.float_value);
-	
+
 	switch (class)
 	{
 		case FP_NAN:
 			//BUG: not portable
 			//shift = (__issignaling(src1.float_value)) ? 8 : 9;
 			break;
-		
+
 		case FP_INFINITE:
 			shift = (signbit(src1.float_value)==0) ? 7 : 0;
 			break;
-		
+
 		case FP_ZERO:
 			shift = (signbit(src1.float_value)==0) ? 4 : 3;
 			break;
-		
+
 		case FP_SUBNORMAL:
 			shift = (signbit(src1.float_value)==0) ? 5 : 2;
 			break;
-		
+
 		case FP_NORMAL:
 			shift = (signbit(src1.float_value)==0) ? 6 : 1;
 			break;
-		
+
 		default:
 			break;
 	}
-	
+
 	reg_set_riscv(E, S, rd, (uint32_t)(1 << shift));
-	
+
 	return;
 }
 
 void rv32f_fcvt_s_w(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	//uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3; //TODO check why there is a rm field?
-	
+
 	rv32f_rep result;
-	
+
 	int32_t src1 = (int32_t)reg_read_riscv(E, S, rs1);
-	
+
 	result.float_value = (float)src1; //cast to float
-	
+
 	freg_set_riscv(E, S, rd, result.bit_value);
-	
+
 	return;
 }
 
 void rv32f_fcvt_s_wu(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	//uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3; //TODO check why there is a rm field?
-	
+
 	rv32f_rep result; //TODO test this
-	
+
 	uint32_t src1 = reg_read_riscv(E, S, rs1);
-	
+
 	result.float_value = (float)src1; //cast to float
-	
+
 	freg_set_riscv(E, S, rd, result.bit_value);
-	
+
 	return;
 }
 
 void rv32f_fmv_w_x(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
-{	
+{
 	freg_set_riscv(E, S, rd, reg_read_riscv(E, S, rs1));
-	
+
 	return;
 }
 
@@ -1007,12 +1007,12 @@ void rv32f_fmv_w_x(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 void rv32d_fld(Engine *E, State *S, uint8_t rs1, uint8_t rd, uint16_t imm0)
 {
 	uint32_t addr = reg_read_riscv(E, S, rs1) + sign_extend(imm0, 12);
-	
+
 	uint64_t data_lsw = (uint64_t)superHreadlong(E, S, addr);
 	uint64_t data_msw = (uint64_t)superHreadlong(E, S, (addr+4));
-	
+
 	uint64_t data = (data_msw << 32) | data_lsw;
-	
+
 	freg_set_riscv(E, S, rd, data);
 
 	return;
@@ -1021,202 +1021,202 @@ void rv32d_fld(Engine *E, State *S, uint8_t rs1, uint8_t rd, uint16_t imm0)
 void rv32d_fsd(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint16_t imm0, uint16_t imm5)
 {
 	uint32_t addr = reg_read_riscv(E, S, rs1) + sign_extend(imm0 + (imm5 << 5), 12);
-	
+
 	uint64_t data = freg_read_riscv(E, S, rs2);
-	
+
 	uint32_t data_lsw = (uint32_t)(data & 0xffffffff);
 	uint32_t data_msw = (uint32_t)((data >> 32) & 0xffffffff);
-	
+
 	superHwritelong(E, S, addr, data_lsw);
 	superHwritelong(E, S, addr+4, data_msw);
-	
+
 	return;
 }
 
 void rv32d_fmadd_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rs3, uint8_t rm, uint8_t rd)
 {
 	rv32d_rep src1, src2, src3, result;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
 	src3.bit64_value = freg_read_riscv(E, S, rs3);
-	
+
 	result.double_value = (src1.double_value * src2.double_value) + src3.double_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit64_value);
-	
+
 	return;
 }
 
 void rv32d_fmsub_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rs3, uint8_t rm, uint8_t rd)
-{	
+{
 	rv32d_rep src1, src2, src3, result;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
 	src3.bit64_value = freg_read_riscv(E, S, rs3);
-	
+
 	result.double_value = (src1.double_value * src2.double_value) - src3.double_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit64_value);
-	
+
 	return;
 }
 
 void rv32d_fnmsub_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rs3, uint8_t rm, uint8_t rd)
 {
 	rv32d_rep src1, src2, src3, result;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
 	src3.bit64_value = freg_read_riscv(E, S, rs3);
-	
+
 	result.double_value = (-1.0 * src1.double_value * src2.double_value) + src3.double_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit64_value);
-	
+
 	return;
 }
 
 void rv32d_fnmadd_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rs3, uint8_t rm, uint8_t rd)
 {
 	rv32d_rep src1, src2, src3, result;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
 	src3.bit64_value = freg_read_riscv(E, S, rs3);
-	
+
 	result.double_value = (-1.0 * src1.double_value * src2.double_value) - src3.double_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit64_value);
-	
+
 	return;
 }
 
 void rv32d_fadd_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	rv32d_rep src1, src2, result;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
-	
+
 	result.double_value = src1.double_value + src2.double_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit64_value);
-	
+
 	return;
 }
 
 void rv32d_fsub_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	rv32d_rep src1, src2, result;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
-	
+
 	result.double_value = src1.double_value - src2.double_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit64_value);
-	
+
 	return;
 }
 
 void rv32d_fmul_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
-	
+
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	rv32d_rep src1, src2, result;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
-	
+
 	result.double_value = src1.double_value * src2.double_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit64_value);
-	
+
 	return;
 }
 
 void rv32d_fdiv_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	rv32d_rep src1, src2, result;
-	
+
 	src1.double_value = freg_read_riscv(E, S, rs1);
 	src2.double_value = freg_read_riscv(E, S, rs2);
-	
+
 	result.double_value = src1.double_value / src2.double_value;
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit64_value);
-	
+
 	return;
 }
 
 void rv32d_fsqrt_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	//rs2 is unused
-	
+
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	rv32d_rep src1, result;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
-	
+
 	result.double_value = sqrt(src1.double_value);
-	
+
 	switch (rm) //TODO check rm value for rounding
 	{
-		
+
 	}
-	
+
 	freg_set_riscv(E, S, rd, result.bit64_value);
-	
+
 	return;
 }
 
@@ -1224,11 +1224,11 @@ void rv32d_fsgnj_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	uint64_t src1 = freg_read_riscv(E, S, rs1);
 	uint64_t src2 = freg_read_riscv(E, S, rs2);
-	
+
 	uint64_t result = (src1 & ((uint64_t)(-1) - ((uint64_t)1 << 63))) | (src2 & ((uint64_t)1 << 63));
-	
+
 	freg_set_riscv(E, S, rd, result);
-	
+
 	return;
 }
 
@@ -1236,11 +1236,11 @@ void rv32d_fsgnjn_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	uint64_t src1 = freg_read_riscv(E, S, rs1);
 	uint64_t src2 = freg_read_riscv(E, S, rs2);
-	
+
 	uint64_t result = (src1 & ((uint64_t)(-1) - ((uint64_t)1 << 63))) | (~src2 & ((uint64_t)1 << 63));
-	
+
 	freg_set_riscv(E, S, rd, result);
-	
+
 	return;
 }
 
@@ -1248,107 +1248,107 @@ void rv32d_fsgnjx_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	uint64_t src1 = freg_read_riscv(E, S, rs1);
 	uint64_t src2 = freg_read_riscv(E, S, rs2);
-	
+
 	uint64_t result = (src1 & ((uint64_t)(-1) - ((uint64_t)1 << 63))) | ((src1 ^ src2) & ((uint64_t)1 << 63));
-	
+
 	freg_set_riscv(E, S, rd, result);
-	
+
 	return;
 }
 
 void rv32d_fmin_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	rv32d_rep src1, src2;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
-	
+
 	freg_set_riscv(E, S, rd, (src1.double_value <= src2.double_value) ? src1.bit64_value : src2.bit64_value);
-	
+
 	return;
 }
 
 void rv32d_fmax_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	rv32d_rep src1, src2;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
-	
+
 	freg_set_riscv(E, S, rd, (src1.double_value >= src2.double_value) ? src1.bit64_value : src2.bit64_value);
-	
+
 	return;
 }
 
 void rv32d_fcvt_s_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	//uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3; //TODO check why there is a rm field?
-	
+
 	//rs2 unused
-	
+
 	rv32f_rep result;
 	rv32d_rep src1;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
-	
+
 	result.float_value = (float)src1.double_value; //cast to float
-	
+
 	freg_set_riscv(E, S, rd, result.bit_value);
-	
+
 	return;
 }
 
 void rv32d_fcvt_d_s(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	//uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3; //TODO check why there is a rm field?
-	
+
 	//rs2 unused
-	
+
 	rv32d_rep result;
 	rv32f_rep src1;
-	
+
 	src1.bit_value = freg_read_riscv(E, S, rs1);
-	
+
 	result.double_value = (double)src1.float_value; //cast to double
-	
+
 	freg_set_riscv(E, S, rd, result.bit64_value);
-	
+
 	return;
 }
 
 void rv32d_feq_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	rv32d_rep src1, src2;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
-	
+
 	reg_set_riscv(E, S, rd, (src1.double_value == src2.double_value) ? 1 : 0);
-	
+
 	return;
 }
 
 void rv32d_flt_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	rv32d_rep src1, src2;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
-	
+
 	reg_set_riscv(E, S, rd, (src1.double_value < src2.double_value) ? 1 : 0);
-	
+
 	return;
 }
 
 void rv32d_fle_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	rv32d_rep src1, src2;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
-	
+
 	reg_set_riscv(E, S, rd, (src1.double_value <= src2.double_value) ? 1 : 0);
-	
+
 	return;
 }
 
@@ -1358,54 +1358,54 @@ void rv32d_fclass_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 	//TODO
 	uint32_t shift;
 	rv32d_rep src1;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
-	
+
 	int class = fpclassify(src1.double_value);
-	
+
 	switch (class)
 	{
 		case FP_NAN:
 			//BUG: not portable
 			//shift = (__issignaling(src1.double_value)) ? 8 : 9;
 			break;
-		
+
 		case FP_INFINITE:
 			shift = (signbit(src1.double_value)==0) ? 7 : 0;
 			break;
-		
+
 		case FP_ZERO:
 			shift = (signbit(src1.double_value)==0) ? 4 : 3;
 			break;
-		
+
 		case FP_SUBNORMAL:
 			shift = (signbit(src1.double_value)==0) ? 5 : 2;
 			break;
-		
+
 		case FP_NORMAL:
 			shift = (signbit(src1.double_value)==0) ? 6 : 1;
 			break;
-		
+
 		default:
 			break;
 	}
-	
+
 	reg_set_riscv(E, S, rd, (uint32_t)(1 << shift));
-	
+
 	return;
 }
 
 void rv32d_fcvt_w_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	//rs2 unused
-	
+
 	rv32d_rep src1;
-	
+
 	uint8_t frm;
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
-	
+
 	/*
 	*Rounding modes - Reference
 	*https://www.gnu.org/software/libc/manual/html_node/Rounding-Functions.html
@@ -1415,27 +1415,27 @@ void rv32d_fcvt_w_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 		case 0b000: //Round to nearest (ties to Even)
 			reg_set_riscv(E, S, rd, (int32_t)rint(src1.double_value));
 			break;
-		
+
 		case 0b001: //Round towards zero
 			reg_set_riscv(E, S, rd, (int32_t)trunc(src1.double_value));
 			break;
-		
+
 		case 0b010:	//Round down (towards -inf)
 			reg_set_riscv(E, S, rd, (int32_t)floor(src1.double_value));
 			break;
-		
+
 		case 0b011: //Round up (towards +inf)
 			reg_set_riscv(E, S, rd, (int32_t)ceil(src1.double_value));
 			break;
-		
+
 		case 0b100: //Round to nearest (ties to Max Magnitude)
 			reg_set_riscv(E, S, rd, (int32_t)round(src1.double_value));
 			break;
-		
+
 		case 0b101: //Invalid. Reserved for future use
 		case 0b110: //Do nothing for now
 			break;
-		
+
 		case 0b111: //Dynamic rounding mode, read from frm
 			frm = (S->riscv->fCSR & (0b111 << 5)) >> 5;
 			switch (frm)
@@ -1443,23 +1443,23 @@ void rv32d_fcvt_w_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 				case 0b000: //Round to nearest (ties to Even)
 					reg_set_riscv(E, S, rd, (int32_t)rint(src1.double_value));
 					break;
-				
+
 				case 0b001: //Round towards zero
 					reg_set_riscv(E, S, rd, (int32_t)trunc(src1.double_value));
 					break;
-				
+
 				case 0b010:	//Round down (towards -inf)
 					reg_set_riscv(E, S, rd, (int32_t)floor(src1.double_value));
 					break;
-				
+
 				case 0b011: //Round up (towards +inf)
 					reg_set_riscv(E, S, rd, (int32_t)ceil(src1.double_value));
 					break;
-				
+
 				case 0b100: //Round to nearest (ties to Max Magnitude)
 					reg_set_riscv(E, S, rd, (int32_t)round(src1.double_value));
 					break;
-				
+
 				case 0b101: //Invalid
 				case 0b110: //Do nothing for now
 				case 0b111:
@@ -1467,23 +1467,23 @@ void rv32d_fcvt_w_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 					break;
 			}
 			break;
-		
+
 		default:
 			break;
 	}
-	
+
 	return;
 }
 
 void rv32d_fcvt_wu_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	rv32d_rep src1;
-	
+
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
-	
+
 	uint8_t frm;
 	uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3;
-	
+
 	/*
 	*Rounding modes - Reference
 	*https://www.gnu.org/software/libc/manual/html_node/Rounding-Functions.html
@@ -1493,27 +1493,27 @@ void rv32d_fcvt_wu_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 		case 0b000: //Round to nearest (ties to Even)
 			reg_set_riscv(E, S, rd, (uint32_t)rint(src1.double_value));
 			break;
-		
+
 		case 0b001: //Round towards zero
 			reg_set_riscv(E, S, rd, (uint32_t)trunc(src1.double_value));
 			break;
-		
+
 		case 0b010:	//Round down (towards -inf)
 			reg_set_riscv(E, S, rd, (uint32_t)floor(src1.double_value));
 			break;
-		
+
 		case 0b011: //Round up (towards +inf)
 			reg_set_riscv(E, S, rd, (uint32_t)ceil(src1.double_value));
 			break;
-		
+
 		case 0b100: //Round to nearest (ties to Max Magnitude)
 			reg_set_riscv(E, S, rd, (uint32_t)round(src1.double_value));
 			break;
-		
+
 		case 0b101: //Invalid. Reserved for future use
 		case 0b110: //Do nothing for now
 			break;
-		
+
 		case 0b111: //Dynamic rounding mode, read from frm
 			frm = (S->riscv->fCSR & (0b111 << 5)) >> 5;
 			switch (frm)
@@ -1521,23 +1521,23 @@ void rv32d_fcvt_wu_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 				case 0b000: //Round to nearest (ties to Even)
 					reg_set_riscv(E, S, rd, (uint32_t)rint(src1.double_value));
 					break;
-				
+
 				case 0b001: //Round towards zero
 					reg_set_riscv(E, S, rd, (uint32_t)trunc(src1.double_value));
 					break;
-				
+
 				case 0b010:	//Round down (towards -inf)
 					reg_set_riscv(E, S, rd, (uint32_t)floor(src1.double_value));
 					break;
-				
+
 				case 0b011: //Round up (towards +inf)
 					reg_set_riscv(E, S, rd, (uint32_t)ceil(src1.double_value));
 					break;
-				
+
 				case 0b100: //Round to nearest (ties to Max Magnitude)
 					reg_set_riscv(E, S, rd, (uint32_t)round(src1.double_value));
 					break;
-				
+
 				case 0b101: //Invalid
 				case 0b110: //Do nothing for now
 				case 0b111:
@@ -1545,43 +1545,43 @@ void rv32d_fcvt_wu_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 					break;
 			}
 			break;
-		
+
 		default:
 			break;
 	}
-	
+
 	return;
 }
 
 void rv32d_fcvt_d_w(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	//uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3; //TODO check why there is a rm field?
-	
+
 	//rs2 unused
-	
+
 	rv32d_rep result;
-	
+
 	int32_t src1 = (int32_t)reg_read_riscv(E, S, rs1);
-	
+
 	result.double_value = (double)src1; //cast to double
-	
+
 	freg_set_riscv(E, S, rd, result.bit64_value);
-	
+
 	return;
 }
 
 void rv32f_fcvt_d_wu(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 {
 	//uint8_t rm = ((instr_r *)&S->riscv->P.EX.instr)->funct3; //TODO check why there is a rm field?
-	
+
 	rv32d_rep result; //TODO test this
-	
+
 	uint32_t src1 = reg_read_riscv(E, S, rs1);
-	
+
 	result.double_value = (double)src1; //cast to double
-	
+
 	freg_set_riscv(E, S, rd, result.bit64_value);
-	
+
 	return;
 }
 


### PR DESCRIPTION
This commit goes someway towards sunflower conforming to section 9.2
of the riscv spec (v2.2). Hopefully, with this commit, anytime a single
precision floating point value is stored in a register the upper
32 bits will be set to 1 making it a valid `quiet nan` double precision
value.

This commit does *not* check floating point values are correctly nan
boxed when reading registers even though this is mandated by the spec.
Maybe a future pull request can implement this.

Refs ##54

---

For reviewing: 758a773 contains only white space changes and 95ddc6d contains the actual changes of note.