### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,20 @@ tools/superH
 #	Downloaded sources
 #
 tools/source/*
+
+#
+#	Bison files
+#
+sim/help.h
+sim/sf.tab.c
+
+
+#
+#	sf build files
+#
+
+sim/mversion.h
+sim/commands.tex
+sim/opstr-*.h
+sim/sf
+sim/sf.output

--- a/.gitignore
+++ b/.gitignore
@@ -12,17 +12,6 @@ sunflower.out
 init.i
 
 #
-#	Built cross compiler binaries
-#
-tools/bin
-tools/superH
-
-#
-#	Downloaded sources
-#
-tools/source/*
-
-#
 #	Bison files
 #
 sim/help.h


### PR DESCRIPTION
079e788: Ignores files generated when building sunflower

f5cbcd3: Removes ignore rules that used to cover files that are now part of the sunflower-toolchain submodules
