### PR TITLE
Add missing header in makefile

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -13,6 +13,7 @@ HEADERS =\
 	batt.h\
 	big-endian-hitachi-sh.h\
 	cache-hitachi-sh.h\
+	config.h\
 	decode-hitachi-sh.h\
 	decode-ti-msp430.h\
 	decode-riscv.h\
@@ -148,4 +149,4 @@ install: $(TARGET)
 	cp $(TARGET) $(BIN)/
 
 clean:
-	$(DEL) $(TARGET) *.o *.core core *.tab.c mversion.h help.h commands.tex opstr-*.h parsedriver.i lex.i sf.output gmon.out sunflower.out 
+	$(DEL) $(TARGET) *.o *.core core *.tab.c mversion.h help.h commands.tex opstr-*.h parsedriver.i lex.i sf.output gmon.out sunflower.out


### PR DESCRIPTION
`config.h` was missing from the list of headers. I assume this was not deliberate but please close this if there is a reason that `config.h` was not part of the list.