### PR TITLE
Print ABI when dumping riscv registers

### DIFF
--- a/sim/machine-riscv.c
+++ b/sim/machine-riscv.c
@@ -2,6 +2,77 @@
 #include "sf.h"
 #include "mextern.h"
 
+static void
+print_integer_register_abi(Engine *E, State *S, ulong reg_index)
+{
+	// See https://github.com/riscv/riscv-elf-psabi-doc/blob/master/riscv-elf.md#integer-register-convention-
+	const char * special_names[] = {
+		"zero",
+		"ra",
+		"sp",
+		"gp",
+		"tp",
+	};
+	if (reg_index < 5)
+	{
+		mprint(E, S, nodeinfo, "%-4s", special_names[reg_index]);
+	}
+	else if (reg_index < 8)
+	{
+		mprint(E, S, nodeinfo, "t%-3u", reg_index - 5);
+	}
+	else if (reg_index < 10)
+	{
+		mprint(E, S, nodeinfo, "s%-3u", reg_index - 8);
+	}
+	else if (reg_index < 18)
+	{
+		mprint(E, S, nodeinfo, "a%-3u", reg_index - 10);
+	}
+	else if (reg_index < 28)
+	{
+		mprint(E, S, nodeinfo, "s%-3u", reg_index - 18 + 2);
+	}
+	else if (reg_index < 32)
+	{
+		mprint(E, S, nodeinfo, "t%-3u", reg_index - 28 + 3);
+	}
+	else
+	{
+		mexit(E, "Cannot get ABI name for invalid index.", -1);
+	}
+}
+
+static void
+print_fp_register_abi(Engine *E, State *S, ulong reg_index)
+{
+	// See https://github.com/riscv/riscv-elf-psabi-doc/blob/master/riscv-elf.md#floating-point-register-convention-
+	if (reg_index < 8)
+	{
+		mprint(E, S, nodeinfo, "ft%-2u", reg_index);
+	}
+	else if (reg_index < 10)
+	{
+		mprint(E, S, nodeinfo, "fs%-2u", reg_index - 8);
+	}
+	else if (reg_index < 18)
+	{
+		mprint(E, S, nodeinfo, "fa%-2u", reg_index - 10);
+	}
+	else if (reg_index < 28)
+	{
+		mprint(E, S, nodeinfo, "fs%-2u", reg_index - 18 + 2);
+	}
+	else if (reg_index < 32)
+	{
+		mprint(E, S, nodeinfo, "ft%-2u", reg_index - 28 + 8);
+	}
+	else
+	{
+		mexit(E, "Cannot get ABI name for invalid index.", -1);
+	}
+}
+
 void
 riscvdumpregs(Engine *E, State *S)
 {
@@ -9,14 +80,18 @@ riscvdumpregs(Engine *E, State *S)
 
 	for (i = 0; i < 32; i++)
 	{
-		mprint(E, S, nodeinfo, "R%-2d\t\t", i);
+		mprint(E, S, nodeinfo, "R%-2d\t", i);
+		print_integer_register_abi(E, S, i);
+		mprint(E, S, nodeinfo, "\t", i);
 		mbitprint(E, S, 32, S->riscv->R[i]);
 		mprint(E, S, nodeinfo, "  [0x%08lx]\n", S->riscv->R[i]);
 	}
-	
+
 	for (i = 0; i < 32; i++)
 	{
-		mprint(E, S, nodeinfo, "fR%-2d\t\t", i);
+		mprint(E, S, nodeinfo, "fR%-2d\t", i);
+		print_fp_register_abi(E, S, i);
+		mprint(E, S, nodeinfo, "\t", i);
 		mbit64print(E, S, 64, S->riscv->fR[i]);
 		mfloatprint(E, S, S->riscv->fR[i]);
 	}
@@ -39,7 +114,7 @@ riscvnewstate(Engine *E, double xloc, double yloc, double zloc, char *trajfilena
 	{
 		mexit(E, "Failed to allocate memory for S->riscv.", -1);
 	}
-    
+
     S->step = riscvstep;
 
     return S;


### PR DESCRIPTION
The ABI names are taken from https://github.com/riscv/riscv-elf-psabi-doc/blob/master/riscv-elf.md and are correct as of commit 29b36616cf2598e2c13ba6de89a95f8400f1e716 on that repo.

### Screenshot:

![screenshot from 2019-02-27 22-26-57](https://user-images.githubusercontent.com/16308754/53527413-cee86c00-3ade-11e9-9595-0b377ecd4b3d.png)


Fixes: https://github.com/phillipstanleymarbell/sunflower-simulator/issues/63
