### PR TITLE
Add syscall support to riscv sunflower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ sunflower.out
 #	Binaries
 #
 *.o
-#*.a
+*.out
 *.sr
 *.map
 init.i

--- a/benchmarks/source/riscv_bubblesort/Makefile
+++ b/benchmarks/source/riscv_bubblesort/Makefile
@@ -1,28 +1,34 @@
 TREEROOT	= ../../..
 include $(TREEROOT)/conf/setup.conf
 
-PROGRAM		= 1
+PROGRAM		= bubble
+INIT		= init
 
 OPTFLAGS	= -g -O0
-CFLAGS		= $(TARGET-ARCH-FLAGS) -Wall # Do not do since we are linking mOS for libc implementation:	-nostdlib -fno-builtin 
-LDFLAGS		= -Ttext $(LOADADDR)
+INCLUDES	= -I$(PREFIX)/include
+CFLAGS		= $(TARGET-ARCH-FLAGS) -Wall
+LDFLAGS		= -Ttext $(LOADADDR) -L$(TOOLSLIB)/$(TARGET) -Map $(PROGRAM).map
 LOADADDR	= 0x08004000
 
 
 OBJS	=\
+	$(INIT).o\
 	$(PROGRAM).o\
 
 
-all:	$(PROGRAM) $(PROGRAM).sr Makefile
+all:	$(PROGRAM).out $(PROGRAM).sr Makefile
 
-$(PROGRAM): $(OBJS)
-	$(LD) $(LDFLAGS) $(OBJS) -o $@ -lm -lc
+$(INIT).o: $(INIT).S
+	$(CC) $(CFLAGS) $(OPTFLAGS) -c $(INIT).S
 
-$(PROGRAM).sr:$(PROGRAM)
-	$(OBJCOPY) -O srec $(PROGRAM) $@
+$(PROGRAM).out: $(OBJS)
+	$(LD) $(LDFLAGS) $(OBJS) -o $@ -lprintf -lc -lgcc -lgloss
+
+$(PROGRAM).sr: $(PROGRAM).out
+	$(OBJCOPY) -O srec $(PROGRAM).out $@
 
 $(PROGRAM).o: $(PROGRAM).c Makefile
-	$(CC) $(CFLAGS) $(OPTFLAGS) -c $(PROGRAM).c
+	$(CC) $(CFLAGS) $(OPTFLAGS) $(INCLUDES) -c $(PROGRAM).c
 
 clean:
-	$(RM) init.i *.o $(PROGRAM) $(PROGRAM).sr $(PROGRAM).map
+	$(RM) *.o *.sr *.out *.map

--- a/benchmarks/source/riscv_bubblesort/bubble.c
+++ b/benchmarks/source/riscv_bubblesort/bubble.c
@@ -1,4 +1,3 @@
-#include<stdio.h>
 
 int main()
 {

--- a/benchmarks/source/riscv_bubblesort/init.S
+++ b/benchmarks/source/riscv_bubblesort/init.S
@@ -1,0 +1,17 @@
+.globl _start
+.globl __errno
+.align	4
+
+_start:
+init:
+.option push
+.option norelax
+	la		gp, __global_pointer$
+.option pop
+	call	main;
+	call 	exit;
+
+__errno:
+	.long	0
+.fp_5:
+  .word 1084227584

--- a/benchmarks/source/riscv_bubblesort/run.m
+++ b/benchmarks/source/riscv_bubblesort/run.m
@@ -2,6 +2,6 @@ sizemem			131072
 settimerdelay		40000
 clockintr		1
 cacheoff
-srecl			1.sr
+srecl			bubble.sr
 run
 on

--- a/sim/mfns.h
+++ b/sim/mfns.h
@@ -88,6 +88,7 @@ int	mread(int fd, char* buf, int len);
 int	mwrite(int fd, char* buf, int len);
 char*	mgetpwd(void);
 ulong	sim_syscall(Engine *, State *, ulong, ulong, ulong, ulong);
+ulong 	riscv_sim_syscall(Engine *, State *, ulong, ulong, ulong, ulong);
 
 
 /*											*/

--- a/sim/op-riscv.c
+++ b/sim/op-riscv.c
@@ -75,7 +75,7 @@ uint64_t nan_box(uint32_t f)
 	return ((~(uint64_t)0) << 32) | f;
 }
 
-/* Checks if a 64-bit value is NaN-boxed 
+/* Checks if a 64-bit value is NaN-boxed
  * returns the lower 32-bits if NaN-boxed and a canonical NaN if otherwise
  */
 uint32_t is_nan_boxed(uint64_t f)
@@ -461,7 +461,6 @@ void riscv_sb(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint16_t imm0, uint
 void 	riscv_fence(Engine *E, State *S) {}
 void 	riscv_fence_i(Engine *E, State *S) {}
 void 	riscv_cor(Engine *E, State *S) {}
-void 	riscv_ecall(Engine *E, State *S) {}
 void 	riscv_ebreak(Engine *E, State *S) {}
 void 	riscv_csrrw(Engine *E, State *S) {}
 void 	riscv_csrrs(Engine *E, State *S) {}
@@ -469,6 +468,15 @@ void 	riscv_csrrc(Engine *E, State *S) {}
 void 	riscv_csrrwi(Engine *E, State *S) {}
 void 	riscv_csrrsi(Engine *E, State *S) {}
 void 	riscv_csrrci(Engine *E, State *S) {}
+
+void 	riscv_ecall(Engine *E, State *S) {
+	// http://man7.org/linux/man-pages/man2/syscall.2.html
+	uint32_t syscall_num = reg_read_riscv(E, S, RISCV_A7);
+	riscv_sim_syscall(E, S, syscall_num,
+				reg_read_riscv(E, S, RISCV_A0),
+				reg_read_riscv(E, S, RISCV_A1),
+				reg_read_riscv(E, S, RISCV_A2));
+}
 
 
 /* RISC-V RV32F instructions */
@@ -1290,7 +1298,7 @@ void rv32d_fmin_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
-	
+
 	result.double_value = fmin(src1.double_value, src2.double_value);
 
 	freg_set_riscv(E, S, rd, result.bit64_value);
@@ -1304,7 +1312,7 @@ void rv32d_fmax_d(Engine *E, State *S, uint8_t rs1, uint8_t rs2, uint8_t rd)
 
 	src1.bit64_value = freg_read_riscv(E, S, rs1);
 	src2.bit64_value = freg_read_riscv(E, S, rs2);
-	
+
 	result.double_value = fmax(src1.double_value, src2.double_value);
 
 	freg_set_riscv(E, S, rd, result.bit64_value);

--- a/sim/syscalls.c
+++ b/sim/syscalls.c
@@ -1,9 +1,9 @@
 /*
 	Copyright (c) 1999-2008, Phillip Stanley-Marbell (author)
- 
+
 	All rights reserved.
 
-	Redistribution and use in source and binary forms, with or without 
+	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions
 	are met:
 
@@ -18,20 +18,20 @@
 
 	*	Neither the name of the author nor the names of its
 		contributors may be used to endorse or promote products
-		derived from this software without specific prior written 
+		derived from this software without specific prior written
 		permission.
 
 	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 	"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-	FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+	FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
 	COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 	INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-	BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+	BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 	CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-	LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-	ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+	LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+	ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
 
@@ -100,7 +100,7 @@ sim_syscall(Engine *E, State *S, ulong type, ulong arg1, ulong arg2, ulong arg3)
 				mprint(E, S, nodeinfo,
 					"Estimated CPU-only Energy = %1.6E\n", S->energyinfo.CPUEtot);
 			}
-				
+
 			mprint(E, S, nodeinfo, "\n\n");
 			S->runnable = 0;
 			E->on = 0;
@@ -149,7 +149,7 @@ sim_syscall(Engine *E, State *S, ulong type, ulong arg1, ulong arg2, ulong arg3)
 				mprint(E, S, nodeinfo, "SYSCALL: SYS_open path=%s (" UHLONGFMT ") flags=" UHLONGFMT "\n",\
 				&S->MEM[(ulong)arg1 - S->MEMBASE], arg1, arg2);
 			}
-			return sys_open(S, (const char *)arg1, (int)arg2); 
+			return sys_open(S, (const char *)arg1, (int)arg2);
 			break;
 		}
 
@@ -379,7 +379,107 @@ sim_syscall(Engine *E, State *S, ulong type, ulong arg1, ulong arg2, ulong arg3)
 	}
 
 	return -1;
-} 
+}
+
+ulong
+riscv_sim_syscall(Engine *E, State *S, ulong type, ulong arg1, ulong arg2, ulong arg3)
+{
+	ulong superH_type;
+
+	switch (type) {
+		case RISCV_SYS_exit:
+		{
+			superH_type = SYS_exit;
+			break;
+		}
+
+		case RISCV_SYS_read:
+		{
+			superH_type = SYS_read;
+			break;
+		}
+		case RISCV_SYS_write:
+		{
+			superH_type = SYS_write;
+			break;
+		}
+		case RISCV_SYS_open:
+		{
+			superH_type = SYS_open;
+			break;
+		}
+		case RISCV_SYS_close:
+		{
+			superH_type = SYS_close;
+			break;
+		}
+		case RISCV_SYS_link:
+		{
+			superH_type = SYS_link;
+			break;
+		}
+		case RISCV_SYS_unlink:
+		{
+			superH_type = SYS_unlink;
+			break;
+		}
+		case RISCV_SYS_chdir:
+		{
+			superH_type = SYS_chdir;
+			break;
+		}
+		case RISCV_SYS_lseek:
+		{
+			superH_type = SYS_lseek;
+			break;
+		}
+		case RISCV_SYS_getpid:
+		{
+			superH_type = SYS_getpid;
+			break;
+		}
+		case RISCV_SYS_fstat:
+		{
+			superH_type = SYS_fstat;
+			break;
+		}
+		case RISCV_SYS_time:
+		{
+			superH_type = SYS_time;
+			break;
+		}
+
+		case RISCV_SYS_stat:
+		{
+			superH_type = SYS_stat;
+			break;
+		}
+
+		case RISCV_SYS_pipe:
+		{
+			superH_type = SYS_pipe;
+			break;
+		}
+		case RISCV_SYS_execve:
+		{
+			superH_type = SYS_execve;
+			break;
+		}
+		default:
+		{
+			superH_type = -1;
+			break;
+		}
+	}
+
+	if (superH_type == -1) {
+		mprint(E, S, nodeinfo, "Node [%d] : Unknown SYSCALL [%ld]!!!\n",\
+				S->NODE_ID, type);
+	} else {
+		return sim_syscall(E, S, superH_type, arg1, arg2, arg3);
+	}
+	return -1;
+}
 
 ulong
 sys_write(Engine *E, State *S, int fd, char *ptr, int len)

--- a/sim/syscalls.h
+++ b/sim/syscalls.h
@@ -1,9 +1,9 @@
 /*
 	Copyright (c) 1999-2008, Phillip Stanley-Marbell (author)
- 
+
 	All rights reserved.
 
-	Redistribution and use in source and binary forms, with or without 
+	Redistribution and use in source and binary forms, with or without
 	modification, are permitted provided that the following conditions
 	are met:
 
@@ -18,20 +18,20 @@
 
 	*	Neither the name of the author nor the names of its
 		contributors may be used to endorse or promote products
-		derived from this software without specific prior written 
+		derived from this software without specific prior written
 		permission.
 
 	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 	"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-	FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
+	FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
 	COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
 	INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-	BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+	BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 	CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-	LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
-	ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+	LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+	ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
 */
 
@@ -42,7 +42,7 @@ enum
 {
 	SYS_exit	= 1,
 	SYS_fork	= 2,
- 
+
 	SYS_read	= 3,
 	SYS_write	= 4,
 	SYS_open	= 5,
@@ -70,4 +70,32 @@ enum
 
 	SYS_utime	= 201,
 	SYS_wait	= 202,
+};
+
+/*
+ * Based on newlib-2.5.0.20170922/libgloss/riscv/machine/syscall.h
+ *
+ * Only syscalls that are defined in that header *and* that sunflower
+ * is able to handle are listed here.
+ */
+enum
+{
+	RISCV_SYS_exit	= 93,
+
+	RISCV_SYS_read	= 63,
+	RISCV_SYS_write	= 64,
+	RISCV_SYS_open	= 1024,
+	RISCV_SYS_close	= 57,
+	RISCV_SYS_link	= 1025,
+	RISCV_SYS_unlink	= 1026,
+	RISCV_SYS_chdir	= 49,
+	RISCV_SYS_lseek	= 62,
+	RISCV_SYS_getpid	= 172,
+	RISCV_SYS_fstat	= 80,
+	RISCV_SYS_time	= 1062,
+
+	RISCV_SYS_stat	= 1038,
+
+	RISCV_SYS_pipe	= 42,
+	RISCV_SYS_execve	= 59,
 };


### PR DESCRIPTION
## Two commits

### 1. Support RISC-V syscalls

Support (some) risc-v syscalls as made by newlib.
The new `riscv_sim_syscall()` function translates syscall numbers
from those used by riscv to those used by superH and calls the existing
(superH supporting) sim_syscall function.

This means that `printf`ing and graceful exiting from riscv programs
should now be possible.

Refs: Source code file newlib-2.5.0.20170922/libgloss/riscv/machine/syscall.h
Refs: http://man7.org/linux/man-pages/man2/syscall.2.html
Refs: https://rv8.io/syscalls.html

### 2. Improve riscv bubble sort example

Improvements to example:

1) Rename project from "1" to "bubble".
2) Add init.S
3) Exit gracefully.

## Notes

I held off adding a printf statement to this code example. newlib's printf requires malloc which sunflower does not support(?). In my local version I have used https://github.com/mpaland/printf which works well but requires an extra dependency (and changes to sunflower-toolchain) so it is not included in this pr.

---

cc: @rjlv2 