### PR TITLE
Fix init script for newton rapson benchmark

### DIFF
--- a/benchmarks/source/riscv_newton-raphson/Makefile
+++ b/benchmarks/source/riscv_newton-raphson/Makefile
@@ -5,7 +5,7 @@ PROGRAM		= 1
 INIT			= init
 
 OPTFLAGS	= -g -O0
-CFLAGS		= $(TARGET-ARCH-FLAGS) -Wall # Do not do since we are linking mOS for libc implementation:	-nostdlib -fno-builtin 
+CFLAGS		= $(TARGET-ARCH-FLAGS) -Wall # Do not do since we are linking mOS for libc implementation:	-nostdlib -fno-builtin
 LDFLAGS		= -Ttext $(LOADADDR)
 LOADADDR	= 0x08004000
 
@@ -20,7 +20,7 @@ $(INIT).o: $(INIT).s
 	$(CC) -O0 -c -o $(INIT).o $(INIT).s
 
 $(PROGRAM): $(OBJS) $(INIT).o
-	$(LD) $(LDFLAGS) $(INIT).o $(OBJS) -o $@ -lm -lc -Map=1.map
+	$(LD) $(LDFLAGS) $(INIT).o $(OBJS) -o $@ -lm -lc -lgloss -Map=1.map
 
 $(PROGRAM).sr:$(PROGRAM)
 	$(OBJCOPY) -O srec $(PROGRAM) $@

--- a/benchmarks/source/riscv_newton-raphson/init.s
+++ b/benchmarks/source/riscv_newton-raphson/init.s
@@ -1,9 +1,15 @@
-.globl _start
+.globl 	_start
+.globl 	__errno
 .align	4
 
 _start:
-
 init:
-	j			main
+.option push
+.option norelax
+	la	gp, __global_pointer$
+.option pop
+	call	main;
+	call	exit;
 
-
+__errno:
+	.long	0


### PR DESCRIPTION
The script now ends (exit system call) without crashing
after running the benchmark.