### PR TITLE
Use RISC-V GPR names for dumpregs

### DIFF
--- a/sim/machine-riscv.c
+++ b/sim/machine-riscv.c
@@ -81,7 +81,7 @@ riscvdumpregs(Engine *E, State *S)
 
 	for (i = 0; i < 32; i++)
 	{
-		mprint(E, S, nodeinfo, "R%-2d\t", i);
+		mprint(E, S, nodeinfo, "x%-2d\t", i);
 		print_integer_register_abi(E, S, i);
 		mprint(E, S, nodeinfo, "\t", i);
 		mbitprint(E, S, 32, S->riscv->R[i]);
@@ -92,7 +92,7 @@ riscvdumpregs(Engine *E, State *S)
 
 	for (i = 0; i < 32; i++)
 	{
-		mprint(E, S, nodeinfo, "fR%-2d\t", i);
+		mprint(E, S, nodeinfo, "f%-2d\t", i);
 		print_fp_register_abi(E, S, i);
 		mprint(E, S, nodeinfo, "\t", i);
 		uint64_t float_bits = S->riscv->fR[i];


### PR DESCRIPTION
Instead of printing _R0_, _R1_, ... and _fR0_, _fR1_, ... when dumping registers print _x0_, _x1_, ... and _f0_, _f1_, ... to match the convention used to number registers in RISC-V specification and documentation.

For example https://github.com/riscv/riscv-elf-psabi-doc/blob/master/riscv-elf.md#integer-register-convention

---

I am mainly making this pull request to test travis.