### PR TITLE
Add new command to display number of times each instruction was run

### DIFF
--- a/sim/lex.c
+++ b/sim/lex.c
@@ -70,6 +70,7 @@ TokenTab token_table [] =
 	{"DUMPSYSREGS",	T_DUMPSYSREGS},				/*+	Show the contents of the system registers.:none									*/
 	{"DUMPMEM",	T_DUMPMEM},				/*+	Show contents of memory.:<start mem address (hexadecimal)> <end mem address (hexadecimal)>			*/
 	{"DUMPPIPE",	T_DUMPPIPE},				/*+	Show the contents of the pipeline stages.:none									*/
+	{"DUMPDISTR",	T_DUMPDISTRIBUTION},			/*+	Show the number of times each instruction was run.:none								*/
 	{"RESETCPU",	T_RESETCPU},				/*+	Reset entire simulated CPU state.:none										*/ 
 	{"SAVE",	T_SAVE},				/*+	Dump memory region to disk.:<start mem addr (hexadecimal)> <end mem addr (hexadecimal)> <filename (string)>	*/
 	{"SETVDD",	T_SETVDD},				/*+	Set operating voltage from frequency.:<Vdd/volts (real)>							*/

--- a/sim/machine-riscv.c
+++ b/sim/machine-riscv.c
@@ -125,6 +125,7 @@ riscvnewstate(Engine *E, double xloc, double yloc, double zloc, char *trajfilena
 	S->dumppipe = riscvdumppipe;
 	S->endian = Little;
 	S->machinetype = MACHINE_RISCV;
+	S->dumpdistribution = riscvdumpdistribution;
 
     if (S->riscv == NULL)
 	{

--- a/sim/machine-riscv.h
+++ b/sim/machine-riscv.h
@@ -41,6 +41,7 @@ struct RiscvState
 	uint64_t fR[RF32FD_fMAX];
 	uint32_t fCSR;
 	RiscvPipe P;
+        uint32_t instruction_distribution[RISCV_OP_MAX]
 };
 
 /*		Entries in the Decode Cache		*/

--- a/sim/main.h
+++ b/sim/main.h
@@ -684,7 +684,8 @@ struct State
 	void 		(*dumpsysregs)(Engine *, State *S);
 	void 		(*resetcpu)(Engine *, State *S);
 	void 		(*dumppipe)(Engine *, State *S);
-	void 		(*pipeflush)(State *S);
+        void 		(*dumpdistribution)(Engine *, State *S);
+        void 		(*pipeflush)(State *S);
 
 	/*	Memory mapped device register read/write functions	*/
 	uchar		(*devreadbyte)(Engine *, State *S, ulong addr);

--- a/sim/mfns.h
+++ b/sim/mfns.h
@@ -691,6 +691,7 @@ void	msp430_jmp(Engine *E, State *S, short offset, MSP430Pipestage *p);
 State*	riscvnewstate(Engine *E, double xloc, double yloc, double zloc, char *trajfilename);
 void    riscvdumpregs(Engine *E, State *S);
 void	riscvdumppipe(Engine *E, State *S);
+void    riscvdumpdistribution(Engine *E, State *S);
 void 	riscvdecode(Engine *E, uint32_t instr, RiscvPipestage *stage);
 uint32_t reg_read_riscv(Engine *E, State *S, uint8_t n);
 void reg_set_riscv(Engine *E, State *S, uint8_t n, uint32_t data);

--- a/sim/pipeline-riscv.c
+++ b/sim/pipeline-riscv.c
@@ -77,6 +77,8 @@ riscvstep(Engine *E, State *S, int drain_pipe)
 
 		riscvdecode(E, tmpinstr, &(S->riscv->P.EX));
 
+		S->riscv->instruction_distribution[S->riscv->P.EX.op]++;
+
 		S->riscv->P.EX.fetchedpc = S->PC;
 		S->PC += 4;
 		S->CLK++;
@@ -190,5 +192,15 @@ riscvdumppipe(Engine *E, State *S)
 
 	mprint(E, S, nodeinfo, "EX: [%s]\n", riscv_opstrs[S->riscv->P.EX.op]);
 	
+	return;
+}
+
+void
+riscvdumpdistribution(Engine *E, State *S)
+{
+	for(int i = 0; i < RISCV_OP_MAX; i++) {
+	    mprint(E, S, nodeinfo, "%-8s {%d}\n", riscv_opstrs[i], S->riscv->instruction_distribution[i]);
+	}
+
 	return;
 }

--- a/sim/sf.y
+++ b/sim/sf.y
@@ -100,6 +100,7 @@
 %token	T_DUMPALL
 %token	T_DUMPMEM
 %token	T_DUMPPIPE
+%token	T_DUMPDISTRIBUTION
 %token	T_DUMPPWR
 %token	T_DUMPREGS
 %token	T_DUMPSYSREGS
@@ -1295,6 +1296,13 @@ sf_cmd		: T_QUIT '\n'
 			if (!yyengine->scanning)
 			{
 				yyengine->cp->dumppipe(yyengine, yyengine->cp);
+			}
+		}
+		| T_DUMPDISTRIBUTION '\n'
+		{
+			if (!yyengine->scanning)
+			{
+				yyengine->cp->dumpdistribution(yyengine, yyengine->cp);
 			}
 		}
 		| T_RESETCPU '\n'


### PR DESCRIPTION
Adds the DUMPDISTR command (short for DUMPDISTRIBUTION) for the risc-v
simulator which will display a list of all 47 RISC instruction and how
many times they had been run in the current simulation.

Co-Authored with Lawrence Berry